### PR TITLE
Removed unused variable

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -66,7 +66,7 @@ void handle_push(stack_t **stack, unsigned int line_number)
 void parse(void)
 {
 	FILE *file;
-	size_t i, n_read;
+	size_t i;
 
 	file = fopen(monty_list.filename, "r");
 	if (file == NULL)


### PR DESCRIPTION
In my previous update, I left an unused variable in the `utils.c` file and it was causing compilation errors.
I thought I removed it before the first pull request #1. But it is fixed now