### PR TITLE
Fixed valgrind uninitialized values error

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -82,6 +82,7 @@ void parse(void)
 		handle_exit();
 	}
 
+	memset(monty_list.buffer, 0, sizeof(char) * BUFF_SIZE);
 	while (fread(monty_list.buffer, BUFF_SIZE, 1, file) != 0)
 		;
 	fclose(file);


### PR DESCRIPTION
This update fixes the valgrind errors by initializing the `monty_list.buffer` to NUL bytes. Essentially setting the whole string to just a `\0` using the `memset()` function. In the future, we may use the `calloc()` but the project restriction doesn't allow us to.