### PR TITLE
Updated to handle 'stack' and 'queue' opcodes

### DIFF
--- a/monty.h
+++ b/monty.h
@@ -42,6 +42,8 @@ typedef struct instruction_s
  * @head: keeps the address of the head node
  * @tail: keeps the address of the tail node (helps to achieve O(1) when
  * inserting at the end)
+ * @ds: keeps track of the specific data structure to use with the linked lists
+ * (either stacks or queues)
  * @size: keeps track of the number of nodes int the queue or stack
  * @line_number: the line number where the instruction appears
  * @filename: the name of the file received on the command line (argv[1])
@@ -56,6 +58,7 @@ typedef struct list_s
 	stack_t *head;
 	stack_t *tail;
 	size_t size;
+	int ds;
 	unsigned int line_number;
 	char *filename;
 	char *buffer;
@@ -68,6 +71,12 @@ typedef struct list_s
 /* monty command context */
 extern list_t monty_list;
 
+/* flags to choose which data structure to use */
+
+#define USE_QUEUE 1
+#define USE_STACK 2
+#define USE_DEFAULT 0 /* default is stack */
+
 /* useful simple macro functions for quick info */
 
 #define top(list) ((list).head->n)
@@ -75,6 +84,10 @@ extern list_t monty_list;
 #define is_empty(list) ((list).size == 0)
 #define is_digit(c) ((c) >= '0' && (c) <= '9')
 #define is_in_ascii_range(c) ((c) >= 0 && (c) <= 127)
+#define queue(opcode) (strcmp((opcode), "queue") == 0)
+#define stack(opcode) (strcmp((opcode), "stack") == 0)
+#define set_ds(opcode)                                                        \
+	((queue(opcode)) ? USE_QUEUE : ((stack(opcode)) ? USE_STACK : USE_DEFAULT))
 
 /* stack operations */
 

--- a/stack_ops.c
+++ b/stack_ops.c
@@ -2,7 +2,7 @@
 
 /**
  * push - inserts a node at the beginning of the list
- * @stack: a pointer to the stack
+ * @stack: a pointer to the stack or queue
  * @data: the integer value to insert
  */
 void push(stack_t **stack, int data)
@@ -24,14 +24,23 @@ void push(stack_t **stack, int data)
 		(*stack)->next = NULL;
 		monty_list.tail = *stack;
 	}
-	else
+	else /* check whether to push into a stack or a queue */
 	{
-		new_frame->next = *stack;
-		(*stack)->prev = new_frame;
-		if ((*stack)->next == NULL)
+		if (monty_list.ds == USE_QUEUE)
+		{
+			monty_list.tail->next = new_frame;
+			new_frame->prev = monty_list.tail;
+			monty_list.tail = new_frame;
+		}
+		else /* use the default - stack */
+		{
+			new_frame->next = *stack;
 			(*stack)->prev = new_frame;
+			if ((*stack)->next == NULL)
+				(*stack)->prev = new_frame;
 
-		*stack = new_frame;
+			*stack = new_frame;
+		}
 	}
 
 	monty_list.size++;
@@ -39,7 +48,7 @@ void push(stack_t **stack, int data)
 
 /**
  * pop - removes a node at the beginning of the linked list
- * @stack: a pointer to the stack
+ * @stack: a pointer to the stack or queue
  * @line_number: the index of the current command
  */
 void pop(stack_t **stack, unsigned int line_number)

--- a/utils.c
+++ b/utils.c
@@ -1,7 +1,7 @@
 #include "monty.h"
 
 /* monty list command context */
-list_t monty_list = {NULL, NULL, 0, 0, NULL, NULL, NULL, NULL, NULL, _free};
+list_t monty_list = {NULL, NULL, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, _free};
 
 /**
  * is_integer - returns 1 if the string is an integer else 0
@@ -133,15 +133,17 @@ void execute_command(char *command)
 	/* handle comments and nop opcode */
 	if (*command == '#')
 		return;
-
 	while (instructs[i].opcode != NULL)
 	{
 		monty_list.opcode = strtok(command, " ");
-
+		if (stack(monty_list.opcode) || queue(monty_list.opcode))
+		{
+			monty_list.ds = set_ds(monty_list.opcode);
+			return;
+		}
 		/* handle the nop opcode and failed missing opcodes */
 		if (monty_list.opcode == NULL || strcmp(monty_list.opcode, "nop") == 0)
 			return;
-
 		if (strcmp(instructs[i].opcode, monty_list.opcode) == 0)
 		{
 			if (strcmp(monty_list.opcode, "push") == 0)
@@ -151,7 +153,6 @@ void execute_command(char *command)
 		}
 		i++; /* keep searching for the right function to handle this */
 	}
-
 	if (instructs[i].opcode == NULL)
 	{
 		/* if we made it this far, the opcode does not exit */


### PR DESCRIPTION
This update handles the `stack` and `queue` opcodes of `monty`.

The original logic of the `push()` is slightly changed to account for when a queue should be used.
No new functions have been created to handle this, the original `push()` is doing all the work and checking
the specific list type to use. This information is obtained from the `set_ds()` macro function.

The relevant lines in `push()` is below

```c
if (monty_list.ds == USE_QUEUE)
{
	monty_list.tail->next = new_frame;
	new_frame->prev = monty_list.tail;
	monty_list.tail = new_frame;
}
else /* use the default - stack */
{
	new_frame->next = *stack;
	(*stack)->prev = new_frame;
	if ((*stack)->next == NULL)
		(*stack)->prev = new_frame;

	*stack = new_frame;
}
```

The `pop()` function wasn't touched, it works the same.