### PR TITLE
Added a function to handle the "rotl" opcode

### DIFF
--- a/monty.h
+++ b/monty.h
@@ -130,4 +130,9 @@ void *_memcpy(void *dest, const void *src, size_t n);
 void *_memset(void *mem_area, int c, unsigned int size);
 void *_realloc(void *old_mem_blk, size_t old_size, size_t new_size);
 
+/* rotation operations */
+
+void rotl(stack_t **stack, __attribute__((unused)) unsigned int line_number);
+void rotr(stack_t **stack, __attribute__((unused)) unsigned int line_number);
+
 #endif /* MONTY_H */

--- a/rot_opcodes.c
+++ b/rot_opcodes.c
@@ -1,0 +1,42 @@
+#include "monty.h"
+
+/**
+ * rotl - rotates the stack to the top
+ * @stack: a pointer to the stack or queue
+ * @line_number: the index of the current command
+ *
+ * Note: The top element of the stack becomes the last one, and the second top
+ * element of the stack becomes the first one. This function never fails
+ */
+void rotl(stack_t **stack, __attribute__((unused)) unsigned int line_number)
+{
+	stack_t *tmp;
+
+	if (size(monty_list) < 2 || size(monty_list) == 0)
+		return; /* there's not enough nodes to rotate */
+
+	/* keep the address of the now old head node and move to next node */
+	tmp = *stack;
+	*stack = (*stack)->next;
+	(*stack)->prev = NULL;
+	monty_list.head = *stack;
+
+	/* adjust links to insert at the end of the list */
+	tmp->next = NULL;
+	monty_list.tail->next = tmp;
+	tmp->prev = monty_list.tail;
+	monty_list.tail = tmp;
+}
+
+/**
+ * rotr - rotates the stack to the bottom.
+ * @stack: a pointer to the stack or queue
+ * @line_number: the index of the current command
+ *
+ * Note: The last element of the stack becomes the top element of the stack.
+ * This function never fails
+ */
+void rotr(stack_t **stack, __attribute__((unused)) unsigned int line_number)
+{
+	/* TODO: Solution here. All operation must be in constant time O(1) */
+}

--- a/utils.c
+++ b/utils.c
@@ -122,17 +122,17 @@ void parse_helper(void)
 void execute_command(char *command)
 {
 	size_t i = 0;
-
 	instruction_t instructs[] = {
 		{"push", handle_push}, {"pop", pop},	  {"pint", pint},
 		{"pall", pall},		   {"add", add},	  {"swap", swap},
 		{"sub", sub},		   {"div", division}, {"mul", mul},
 		{"mod", mod},		   {"pchar", pchar},  {"pstr", pstr},
-		{NULL, NULL}};
+		{"rotl", rotl},		   {"rotr", rotr},	  {NULL, NULL}};
 
 	/* handle comments and nop opcode */
 	if (*command == '#')
 		return;
+
 	while (instructs[i].opcode != NULL)
 	{
 		monty_list.opcode = strtok(command, " ");


### PR DESCRIPTION
Here's the pseudocode and thought process I used to handle this function.

![image](https://github.com/Emyjakarta/monty/assets/48143641/2c89ea6b-ae3a-4ae6-95bf-435c6b5d2a18)

Currently, it works very well based on my tests. I know you (@Emyjakarta) will be doing the `rotr()` function which is the opposite of what I just did here. The approach is almost the same as this one, so the logic used for this would prove useful.

Go and ahead check it out to see if everything works fine.