### PR TITLE
valgrind error/fixed segmentation fault

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -134,7 +134,7 @@ void execute_command(char *command)
 	while (instructs[i].opcode != NULL)
 	{
 		monty_list.opcode = strtok(command, " \t");
-		if ((monty_list.opcode != NULL || *monty_list.opcode) &&
+		if ((monty_list.opcode != NULL) &&
 			(is_stack(monty_list.opcode) || is_queue(monty_list.opcode)))
 		{
 			monty_list.ds = set_ds(monty_list.opcode);


### PR DESCRIPTION
Fixed valgrind error (segmentation fault) as a result of dereferencing a null pointer (*monty_list.opcode).