### PR TITLE
Updated to use the 'getline' function & Code Refactored

### DIFF
--- a/monty.h
+++ b/monty.h
@@ -1,6 +1,7 @@
 #ifndef MONTY_H
 #define MONTY_H
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,7 +51,7 @@ typedef struct instruction_s
  * @buffer: the buffer to store the data from the file
  * @opcode: the opcode to work with
  * @value: used when the @opcode is "push"
- * @commands: an array of commands containing each instruction from the file
+ * @fileptr: used to handle file pointers (buffered I/O)
  * @cleanup: a cleanup function for each element in the list
  */
 typedef struct list_s
@@ -64,7 +65,7 @@ typedef struct list_s
 	char *buffer;
 	char *opcode;
 	char *value;
-	char **commands;
+	FILE *fileptr;
 	void (*cleanup)(void **);
 } list_t;
 
@@ -101,11 +102,9 @@ void pall(stack_t **stack, __attribute__((unused)) unsigned int line_number);
 /* utility functions */
 
 void parse(void);
-void parse_helper(void);
 void handle_exit(void);
 int is_integer(const char *str);
 void execute_command(char *command);
-char **tokenize(char *str, const char *delim);
 void handle_push(stack_t **stack, unsigned int line_number);
 
 /* monty math operations */
@@ -123,7 +122,6 @@ void pchar(__attribute__((unused)) stack_t **stack, unsigned int line_number);
 
 /* custom memory functions */
 
-void free_cmds(void);
 void _free(void **ptr);
 void safe_free_stack(stack_t **stack);
 void *_calloc(unsigned int nmemb, unsigned int size);

--- a/more_utils.c
+++ b/more_utils.c
@@ -21,80 +21,13 @@ void handle_exit(void)
 	/* cleanup the buffer */
 	monty_list.cleanup((void **)&monty_list.buffer);
 
-	/* cleanup space for the commands array */
-	free_cmds();
-
 	/* clear the stack */
 	safe_free_stack(&monty_list.head);
 
+	/* close the file pointer */
+	if (monty_list.fileptr != NULL)
+		fclose(monty_list.fileptr);
+
 	/* now exit with the failure */
 	exit(EXIT_FAILURE);
-}
-
-/**
- * free_cmds - handles memory deallocation for the commands array
-*/
-void free_cmds(void)
-{
-	size_t i;
-
-	if (monty_list.commands == NULL)
-		return;
-
-	for (i = monty_list.line_number - 1; monty_list.commands[i] != NULL; i++)
-	{
-		monty_list.cleanup((void **)&monty_list.commands[i]);
-	}
-	monty_list.cleanup((void **)&monty_list.commands);
-}
-
-/**
- * tokenize - returns a string array of strings based on a delimiter
- * @str: the string to tokenize
- * @delim: the delimiter
- *
- * Return: a NULL-terminated string array of words
- */
-char **tokenize(char *str, const char *delim)
-{
-	char *token = NULL, *dup_str = NULL, **commands = NULL;
-	size_t num_of_tokens, i;
-
-	if (str == NULL || *str == '\0' || delim == NULL)
-		return (NULL);
-
-	/* tokenize the input string */
-	dup_str = strdup(str);
-	if (dup_str == NULL)
-	{
-		fprintf(stderr, "Error: malloc failed\n");
-		handle_exit();
-	}
-	token = strtok(dup_str, delim);
-	num_of_tokens = 0;
-	while (token != NULL)
-	{
-		++num_of_tokens; /* count all the tokens */
-		token = strtok(NULL, delim);
-	}
-	free(dup_str);
-
-	if (num_of_tokens > 0)
-	{
-		commands = _calloc(num_of_tokens + 1, sizeof(char *));
-		if (commands == NULL)
-		{
-			fprintf(stderr, "Error: malloc failed\n");
-			handle_exit();
-		}
-		token = strtok(str, delim);
-		i = 0;
-		while (token != NULL)
-		{
-			commands[i++] = strdup(token);
-			token = strtok(NULL, delim);
-		}
-		commands[i] = NULL;
-	}
-	return (commands);
 }

--- a/utils.c
+++ b/utils.c
@@ -11,16 +11,27 @@ list_t monty_list = {NULL, NULL, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, _free};
  */
 int is_integer(const char *str)
 {
+	int numbers = 0;
+
 	if (str == NULL || *str == '\0')
 		return (0);
 
+	if (*str == '-' || *str == '+')
+		str++; /* moved past the sign */
+
 	while (*str != '\0')
 	{
-		if (is_digit(*str) || str[0] == '-')
+		if (is_digit(*str))
+		{
 			str++; /* we found a number, keep searching */
+			numbers++;
+		}
 		else
 			return (0); /* non-integer found */
 	}
+
+	if (numbers == 0)
+		return (0);
 
 	return (1); /* if we got this far, it's definitely an integer */
 }
@@ -48,11 +59,11 @@ void handle_push(stack_t **stack, unsigned int line_number)
  */
 void parse(void)
 {
-	FILE *file;
-	size_t n_read, size = BUFF_SIZE, total_read = 0;
+	size_t size = BUFF_SIZE;
+	ssize_t n_read;
 
-	file = fopen(monty_list.filename, "r");
-	if (file == NULL)
+	monty_list.fileptr = fopen(monty_list.filename, "r");
+	if (monty_list.fileptr == NULL)
 	{
 		fprintf(stderr, "Error: Can't open file %s\n", monty_list.filename);
 		handle_exit();
@@ -62,59 +73,31 @@ void parse(void)
 	if (monty_list.buffer == NULL)
 	{
 		fprintf(stderr, "Error: malloc failed\n");
-		fclose(file);
+		fclose(monty_list.fileptr);
 		handle_exit();
 	}
 
-	while ((n_read = fread(monty_list.buffer + total_read, sizeof(char),
-						   size - total_read, file)) > 0)
-	{
-		total_read += n_read;
-		if (total_read >= size)
-		{
-			monty_list.buffer = _realloc(monty_list.buffer, size, size * 2);
-			if (monty_list.buffer == NULL)
-			{
-				fprintf(stderr, "Error: malloc failed\n");
-				fclose(file);
-				handle_exit();
-			}
-			size *= 2;
-		}
-	}
-	fclose(file);
-	if (*monty_list.buffer == '\0')
-		monty_list.cleanup((void **)&monty_list.buffer);
-	else
-		parse_helper();
-}
-
-/**
- * parse_helper - a helper function to complete the parsing before execution
- */
-void parse_helper(void)
-{
-	size_t i;
-
-	monty_list.commands = tokenize(monty_list.buffer, "\n");
-	monty_list.cleanup((void **)&monty_list.buffer);
-
-	if (monty_list.commands == NULL)
-		return; /* probably we received a bunch of whitespaces or nothing */
-
-	i = 0;
-	while (monty_list.commands[i] != NULL)
+	while ((n_read = getline(&monty_list.buffer, &size, monty_list.fileptr)) !=
+		   -1)
 	{
 		++monty_list.line_number;
-
-		/* handle the command execution and clean up */
-		execute_command(monty_list.commands[i]);
-		monty_list.cleanup((void **)&monty_list.commands[i]);
-
-		i++; /* get the next command */
+		execute_command(monty_list.buffer);
 	}
-	/* clean up and leave here */
-	monty_list.cleanup((void **)&monty_list.commands);
+
+	/* let's handle errors that can error on EOF */
+	if (n_read == -1)
+	{
+		/* let's check for memory allocation or reallocation failures */
+		if (errno == ENOMEM)
+		{
+			fprintf(stderr, "Error: malloc failed\n");
+			handle_exit();
+		}
+	}
+
+	/* close the file pointer and cleanup memory for the buffer */
+	fclose(monty_list.fileptr);
+	monty_list.cleanup((void **)&monty_list.buffer);
 }
 
 /**
@@ -133,7 +116,7 @@ void execute_command(char *command)
 
 	while (instructs[i].opcode != NULL)
 	{
-		monty_list.opcode = strtok(command, " \t");
+		monty_list.opcode = strtok(command, " \t\n");
 		if ((monty_list.opcode != NULL) &&
 			(is_stack(monty_list.opcode) || is_queue(monty_list.opcode)))
 		{
@@ -147,7 +130,7 @@ void execute_command(char *command)
 		if (strcmp(instructs[i].opcode, monty_list.opcode) == 0)
 		{
 			if (strcmp(monty_list.opcode, "push") == 0)
-				monty_list.value = strtok(NULL, " \t");
+				monty_list.value = strtok(NULL, " \t\n");
 			instructs[i].f(&monty_list.head, monty_list.line_number);
 			return; /* we just executed a command, is there more? */
 		}


### PR DESCRIPTION
This update eliminates the use of `parse_helper()` function as it is no longer required. Additionally, tokenization is now performed directly instead of calling the `tokenize()` function, which used to cause loss of valuable information. With this update, the issue is resolved, and the tokenization process is expected to work as intended.