### PR TITLE
Removed residual files after installation and installed the man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS = -Wall -Werror -Wextra -pedantic -std=c89
 
 SRCS = $(wildcard *.c)
-OBJS = $(SRCS:.c=.o)
+OBJS = $(SRCS:*.c=*.o)
 EXEC = monty
 
 .PHONY: all clean

--- a/install.sh
+++ b/install.sh
@@ -6,14 +6,20 @@ if [ $UID -ne 0 ]; then
 	exit 1
 fi
 
-# Compile and copy the executable to the /usr/bin so it will be accessible throughout
-make && cp monty /usr/bin/monty
+# Compile the source files
+make 
 
 # Verify if it compiled successfully
 if [ $? -eq 0 ]; then
+	# Copy the executable to the /usr/bin so it will be accessible throughout
+	cp monty /usr/bin/monty
+	# Install the man page
+	cp monty.1 /usr/share/man/man1/monty.1
+	# Update the man page database
+	mandb
+
 	echo "Monty 0.99 installed successfully to /usr/bin"
+	echo "Man page installed successfully"
 else
 	echo "Failed to compile. Please check the source code and try again."
 fi
-
-

--- a/monty.1
+++ b/monty.1
@@ -2,7 +2,7 @@
 
 .SH NAME
 monty \- Monty Bytecode Interpreter
-Monty 0.98 is a scripting language that is first compiled into Monty byte codes (Just like Python). It relies on a unique stack and queue, with specific instructions to manipulate it.
+Monty 0.99 is a scripting language that is first compiled into Monty byte codes (Just like Python). It relies on a unique stack and queue, with specific instructions to manipulate it.
 
 .SH SYNOPSIS
 .B monty


### PR DESCRIPTION
This update deletes the residual object files after installation and copies the man page (monty.1) into the user's /usr/share/man/man1 directory so that the user can access it by using man monty.